### PR TITLE
Refactor app to use new correlation tracker API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ models/
 
 alwaysai.target.json
 alwaysai.project.json
+
+*.jpeg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 ARG ALWAYSAI_HW="default"
-FROM alwaysai/edgeiq:${ALWAYSAI_HW}-1.1.0
+FROM alwaysai/edgeiq:${ALWAYSAI_HW}-1.2.0
 

--- a/app.py
+++ b/app.py
@@ -2,7 +2,6 @@ import time
 
 import edgeiq
 from contraband_summary import ContrabandSummary
-import cv2
 
 """
 Detect items that are considered contraband for working or learning from home,
@@ -60,9 +59,6 @@ def main():
     def handle_detected_contraband(object_id, prediction):
         print('Detected {}!'.format(prediction.label))
         contraband_summary.update_contraband(prediction.label)
-        cv2.imwrite("{}_{}.jpeg".format(prediction.label, \
-            time.strftime('%Y-%m-%d %Hh_%Mm_%Ss', time.localtime())), \
-                contraband_summary.get_image())
 
     tracker = edgeiq.CorrelationTracker(
             max_objects=5,

--- a/app.py
+++ b/app.py
@@ -1,39 +1,36 @@
 import time
 import edgeiq
-from contraband_summary import ContrabandSummary 
+from contraband_summary import ContrabandSummary
 """
-Detect items that are considered contraband for working or learning 
-from home, namely cell phones, headphones, books, etc. 
+Detect items that are considered contraband for working or learning from home,
+namely cell phones, headphones, books, etc.
 
-This example app uses two detection models in order to increase the
-number of detections as well as the types of detections. The models this 
-app uses are "alwaysai/ssd_mobilenet_v2_oidv4" and 
+This example app uses two detection models in order to increase the number of
+detections as well as the types of detections. The models this app uses are
+"alwaysai/ssd_mobilenet_v2_oidv4" and
 "alwaysai/ssd_inception_v2_coco_2018_01_28".
 
-Additionally, this app uses a object tracker, which reduces the overhead 
-associated with inference time and lessens the strain on your deployment device. 
+Additionally, this app uses a object tracker to reduce instances where the same
+object is detected as a new object.
 
-To change the computer vision model, follow this guide:
-https://dashboard.alwaysai.co/docs/application_development/changing_the_model.html
-
-To change the engine and accelerator, follow this guide:
-https://dashboard.alwaysai.co/docs/application_development/changing_the_engine_and_accelerator.html
+To change the computer vision model, the engine and accelerator, and add
+additional dependencies read this guide:
+https://alwaysai.co/docs/application_development/configuration_and_packaging.html
 """
 
+
 def main():
-
-    # The current frame index
-    frame_idx = 0
-
-    # The number of frames to skip before running detector
-    detect_period = 50
-
     # if you would like to test an additional model, add one to the list below:
-    models = ["alwaysai/ssd_mobilenet_v2_oidv4","alwaysai/ssd_inception_v2_coco_2018_01_28"]
+    models = [
+            "alwaysai/ssd_mobilenet_v2_oidv4",
+            "alwaysai/ssd_inception_v2_coco_2018_01_28"]
 
-    # include any labels that you wish to detect from any models (listed above in 'models') here in this list
-    detected_contraband = ["Pen", "cell phone", "backpack", "book", "Book", "Ring binder", "Headphones", "Calculator", "Mobile phone", 
-    "Telephone", "Microphone", "Ipod", "Remote control"]
+    # include any labels that you wish to detect from any models (listed above
+    # in 'models') here in this list
+    contraband_labels = [
+            "Pen", "cell phone", "backpack", "book", "Book",
+            "Ring binder", "Headphones", "Calculator", "Mobile phone",
+            "Telephone", "Microphone", "Ipod", "Remote control"]
 
     # load all the models (creates a new object detector for each model)
     detectors = []
@@ -43,7 +40,8 @@ def main():
         obj_detect = edgeiq.ObjectDetection(model)
         obj_detect.load(engine=edgeiq.Engine.DNN)
 
-        # track the generated object detection items by storing them in detectors
+        # track the generated object detection items by storing them
+        # in detectors
         detectors.append(obj_detect)
 
         # print the details of each model to the console
@@ -52,14 +50,24 @@ def main():
         print("Accelerator: {}\n".format(obj_detect.accelerator))
         print("Labels:\n{}\n".format(obj_detect.labels))
 
-    tracker = edgeiq.CorrelationTracker(max_objects=5)
     fps = edgeiq.FPS()
     contraband_summary = ContrabandSummary()
 
+    new_contraband_detections = []
+
+    def handle_detected_contraband(object_id, prediction):
+        print('Detected {}!'.format(prediction.label))
+        new_contraband_detections.append(prediction)
+
+    tracker = edgeiq.CorrelationTracker(
+            max_objects=5,
+            deregister_frames=30,
+            enter_cb=handle_detected_contraband)
+
     try:
-        with edgeiq.WebcamVideoStream(cam=0) as video_stream, \
+        with edgeiq.WebcamVideoStream(cam=2) as video_stream, \
                 edgeiq.Streamer() as streamer:
-            
+
             # Allow Webcam to warm up
             time.sleep(2.0)
             fps.start()
@@ -67,47 +75,35 @@ def main():
             # loop detection
             while True:
                 frame = video_stream.read()
-                predictions_to_markup = []
-                text = [""]
+                predictions = []
 
-                # only analyze every 'detect_period' frame (i.e. every 50th in original code)
-                if frame_idx % detect_period == 0:
+                # gather data from the all the detectors
+                for i in range(0, len(detectors)):
+                    results = detectors[i].detect_objects(
+                        frame, confidence_level=.2)
+                    filtered_predictions = edgeiq.filter_predictions_by_label(
+                            results.predictions, contraband_labels)
 
-                    # gather data from the all the detectors 
-                    for i in range(0, len(detectors)):
-                        results = detectors[i].detect_objects(
-                            frame, confidence_level=.2)
+                    # append each prediction
+                    predictions.extend(filtered_predictions)
 
-                        # Stop tracking old objects
-                        if tracker.count:
-                            tracker.stop_all()
+                # Clear list of new detections
+                new_contraband_detections = []
+                tracked_contraband = tracker.update(predictions, frame)
+                for c in new_contraband_detections:
+                    contraband_summary.contraband_alert(c.label, frame)
 
-                        # append each prediction
-                        predictions = results.predictions
-                        for prediction in predictions:
-
-                            if (prediction.label.strip() in detected_contraband):
-                                contraband_summary.contraband_alert(prediction.label, frame)
-                                predictions_to_markup.append(prediction)
-                                tracker.start(frame, prediction) 
-                else:
-
-                    # if there are objects being tracked, update the tracker with the new frame
-                    if tracker.count:
-
-                        # get the new predictions for the objects being tracked, used to markup the frame
-                        predictions_to_markup = tracker.update(frame)
+                tracked_predictions = [prediction for (object_id, prediction) in tracked_contraband.items()]
 
                 # mark up the frame with the predictions for the contraband objects
                 frame = edgeiq.markup_image(
-                        frame, predictions_to_markup, show_labels=True,
+                        frame, tracked_predictions, show_labels=True,
                         show_confidences=False, colors=obj_detect.colors)
-                   
+
                 # send the collection of contraband detection points (string and video frame) to the streamer
                 text = contraband_summary.get_contraband_string()
-                
+
                 streamer.send_data(frame, text)
-                frame_idx += 1
                 fps.update()
 
                 if streamer.check_exit():

--- a/contraband_summary.py
+++ b/contraband_summary.py
@@ -9,24 +9,29 @@ time they occurred, and the video frame of the incident.
 class ContrabandSummary:
     def __init__(self):
         self.contraband_detections = []
+        self.current_image = None
 
-    def contraband_alert(self, contraband, frame):
+    def update_contraband(self, contraband):
+        detect_time = time.localtime()
+        self.contraband_detections.append((contraband, detect_time))
+        
+    def get_summary(self):
         """
-        Prints the detection to the console. Input frame can be saved to disk.
+        Prints the detection to the console.
 
         Parameters
         -------
         contraband : string
             The label of the detected object
-
-        frame: []
-            A numpy array of the moment the contraband was detected
         """
-        detect_time = time.localtime()
-        self.contraband_detections.append((contraband, detect_time, frame))
         items = self.get_contraband_string()
-        
         print(*items)
+
+    def update_image(self, frame):
+        self.current_image = frame
+
+    def get_image(self):
+        return self.current_image
 
     def get_contraband_string(self):
         """
@@ -38,7 +43,7 @@ class ContrabandSummary:
             A list of text describing all of the detected contraband and the time of detection
         """
         contraband_string = [""]
-        for contraband, detect_time, frame in self.contraband_detections:
+        for contraband, detect_time in self.contraband_detections:
             string_time = time.strftime('%Y-%m-%d %H:%M:%S', detect_time)
             contraband_string.append(contraband + " detected at " + string_time + "\n")
         return contraband_string

--- a/contraband_summary.py
+++ b/contraband_summary.py
@@ -1,4 +1,7 @@
 import time
+
+import cv2
+
 """
 Tracks all occurrences of contraband detections. Stores tuples of
 (detection, time, frame) in a list, contraband_detections, that
@@ -12,8 +15,17 @@ class ContrabandSummary:
         self.current_image = None
 
     def update_contraband(self, contraband):
+        """Logs the contraband detected and writes out 
+        a snapshot image of the event.
+
+        Args:
+            contraband (string): The label of the contraband object.
+        """
         detect_time = time.localtime()
         self.contraband_detections.append((contraband, detect_time))
+        cv2.imwrite("{}_{}.jpeg".format(contraband, \
+            time.strftime('%Y-%m-%d %Hh_%Mm_%Ss', time.localtime())), \
+                self.get_image())
         
     def get_summary(self):
         """


### PR DESCRIPTION
I did some refactoring to move to the new `CorrelationTracker` API. @lilamullany There was one place where it was doing `.strip()` on the label before checking against the list. Was that necessary or a precaution? I switched over to the filtering in our library, but if the `strip()` was required that could indicate an issue in the labels of the model, or in how we're parsing them.

I removed the periodic detection to simplify the app since with the new API it doesn't make as much sense to run our tracking in that configuration.

There's one more layer of improvement we could do: remove the `frame` parameter from `contraband_summary.contraband_alert()` and move that function into the callback. Then, a simple flag could be set if any new contraband was detected and that info could be used to capture a frame.